### PR TITLE
feat:(Test) initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ansible-test
+login# ansible-test
 
 ## First install
 

--- a/playbook/group_vars/all.yml
+++ b/playbook/group_vars/all.yml
@@ -1,2 +1,3 @@
 ---
 lp: { env: staging }
+prometheus_port: 9091

--- a/playbook/roles/prometheus/defaults/main.yml
+++ b/playbook/roles/prometheus/defaults/main.yml
@@ -3,3 +3,4 @@
 prometheus_version: 2.17.1
 prometheus_host: localhost
 prometheus_config: prometheus.default.yml.j2
+prometheus_port: 9090

--- a/playbook/roles/prometheus/handlers/main.yml
+++ b/playbook/roles/prometheus/handlers/main.yml
@@ -11,6 +11,13 @@
   become: true
   listen: "reload prometheus"
 
+- name: Stop prometheus.service
+  service:
+    name: prometheus.service
+    state: stopped
+  become: true
+  listen: "stop prometheus"
+
 - name: Restart prometheus.service
   service:
     name: prometheus.service
@@ -20,11 +27,11 @@
 
 - name: Wait for prometheus API is up & running
   uri:
-    url: "http://localhost:9090/-/healthy/"
+    url: "http://localhost:{{ prometheus_port }}/-/healthy/"
     status_code: 200
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 10
   delay: 1
   when: not ansible_check_mode
   listen: "wait for prometheus"

--- a/playbook/roles/prometheus/tasks/main.yml
+++ b/playbook/roles/prometheus/tasks/main.yml
@@ -114,6 +114,7 @@
     name: prometheus.service
     state: restarted
     enabled: true
+    daemon_reload: yes
   become: true
   tags:
     - prometheus

--- a/playbook/roles/prometheus/tasks/main.yml
+++ b/playbook/roles/prometheus/tasks/main.yml
@@ -112,10 +112,8 @@
 - name: Start prometheus.service
   service:
     name: prometheus.service
-    state: started
+    state: restarted
     enabled: true
-  notify:
-    - wait for prometheus
   become: true
   tags:
     - prometheus
@@ -123,3 +121,4 @@
 
 - name: flush_handlers
   meta: flush_handlers
+  

--- a/playbook/roles/prometheus/templates/prometheus.service.j2
+++ b/playbook/roles/prometheus/templates/prometheus.service.j2
@@ -15,7 +15,7 @@ ExecStart=/usr/local/bin/prometheus \
     --web.enable-admin-api \
     --web.console.templates=/usr/local/etc/prometheus/consoles \
     --web.console.libraries=/usr/local/etc/prometheus/console_libraries \
-    --web.listen-address=:9090
+    --web.listen-address=:{{ prometheus_port }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I have a small problem...
I had to do a "converge destroy" and then "converge -- -- diff" to have it take the port changes into account... from 9090 to 9091 and vise versa.
I'm unable to make the prometheus service to reload after the change within the playbook... however doing it manually via the command line works fine... :

- $: molecule converge -- --diff      #default port 9090
- $: curl http://localhost:59090/metrics | grep "promhttp_metric_handler_requests_total"
    # result "OK"

- $: molecule  converge -- --diff     #group-vars/all.yml port 9091
- $: curl http://localhost:59091/metrics | grep "promhttp_metric_handler_requests_total"
   # result "Connection Reset by Peer"

- $: molecule login
vagrant@test2:~$ sudo -i
root@test2:~# systemctl daemon-reload
root@test2:~# systemctl restart prometheus
root@test2:~# exit
logout
vagrant@test2:~$ exit

- $: curl http://localhost:59091/metrics | grep "promhttp_metric_handler_requests_total"
   # result "OK"